### PR TITLE
updated to match GA and handle project alias if present

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,35 +5,29 @@ cd $(dirname $0)
 . utils
 . ../../environment
 
-PROJECT=$(osc status | sed -n '1 { s/.* //; p; }')
+PROJECT=$(oc status | sed -n '1 { s/.* //;s/(//;s/)//;  p; }')
 
-osc create -f - <<EOF || true
-kind: ImageStream
-apiVersion: v1beta1
-metadata:
-  name: reverseproxy
-  labels:
-    service: reverseproxy
-    function: frontend
-EOF
 
-osc create -f - <<EOF
+oc create -f - <<EOF
 kind: BuildConfig
-apiVersion: v1beta1
+apiVersion: v1
 metadata:
   name: reverseproxy
   labels:
     service: reverseproxy
     function: frontend
-triggers:
-- type: generic
-  generic:
-    secret: secret
-parameters:
+spec:
+  triggers:
+  - type: generic
+    generic:
+      secret: secret
   strategy:
-    type: STI
-    stiStrategy:
-      image: docker.io/cicddemo/sti-httpd
+    type: Source
+    sourceStrategy:
+      from:
+        kind: ImageStreamTag
+        name: sti-httpd:latest
+        namespace: openshift
   source:
     type: Git
     git:


### PR DESCRIPTION
Not sure if you plan to use this at all but it was named in INTEGRATION_REPOS for example so it breaks at go.sh.

Unfortunately wasn't able to test on https://console.stg.openshift.com which I have been using, it doesn't launch any webserver or reverseproxy pod for example (!?) 

Due to my project naming, using an alias oc status gives
$ oc status
In project infra (infra-jbrannst)
...

Which requires stripping the parenthesis.
